### PR TITLE
[ExampleApp] Set cache_store to null_store in test environment

### DIFF
--- a/example_app/config/environments/test.rb
+++ b/example_app/config/environments/test.rb
@@ -33,4 +33,6 @@ ExampleApp::Application.configure do
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
+
+  config.cache_store = :null_store
 end


### PR DESCRIPTION
This causes a couple tests to break when disconnected from the internet because it's currently hitting the Google API to geocode. Once https://github.com/thoughtbot/geocoding_on_rails/pull/15 gets squashed/merged, disconnecting from the internet and having this applied should result in a fully green suite since all external requests will be stubbed out.
