### PR TITLE
Fix broken link to Geocoding on Rails site

### DIFF
--- a/book/sample.md
+++ b/book/sample.md
@@ -12,7 +12,7 @@ product.
 If you enjoy the sample, you can get access to the entire book and sample
 application at:
 
-<https://learn.thoughtbot.com/geocodingonrails>
+<http://geocodingonrails.com>
 
 As a purchaser of the book, you also get access to:
 
@@ -51,6 +51,6 @@ get access to the full content, the example application, ongoing updates, and
 the ability to get your questions about Ruby on Rails answered by us, you can
 pick it up on our website:
 
-<https://learn.thoughtbot.com/geocodingonrails>
+<http://geocodingonrails.com>
 
 <<[links.md]

--- a/release/geocoding-on-rails-sample.html
+++ b/release/geocoding-on-rails-sample.html
@@ -64,7 +64,7 @@ code > span.er { color: #ff0000; font-weight: bold; }
 <p>The code samples in this book come from commits in the <a href="https://github.com/thoughtbot/geocoding-on-rails/tree/master/example_app">bundled example application</a>. The example application is a Rails app which lets users search for Starbucks locations nearby. Take a look at the <a href="https://github.com/thoughtbot/geocoding-on-rails/blob/master/example_app/README.md">README</a> for instructions on setting it up.</p>
 <p>This sample contains a few hand-picked sections covering various aspects of application development and performance improvements: plotting points on a map, geocoding browser requests from the server and caching results from external requests. Because these sections are pulled directly from the book, you're able to get a sense for the content, style, and delivery of the product.</p>
 <p>If you enjoy the sample, you can get access to the entire book and sample application at:</p>
-<p><a href="https://learn.thoughtbot.com/geocodingonrails">https://learn.thoughtbot.com/geocodingonrails</a></p>
+<p><a href="http://geocodingonrails.com">http://geocodingonrails.com</a></p>
 <p>As a purchaser of the book, you also get access to:</p>
 <ul>
 <li>Multiple formats, including HTML, PDF, EPUB, and Kindle.</li>
@@ -352,7 +352,7 @@ config.cache_store = <span class="st">:null_store</span></code></pre>
 <section class="level1" id="closing">
 <h1><a href="#closing">Closing</a></h1>
 <p>Thanks for checking out the sample of <em>Geocoding on Rails</em>. If you’d like to get access to the full content, the example application, ongoing updates, and the ability to get your questions about Ruby on Rails answered by us, you can pick it up on our website:</p>
-<p><a href="https://learn.thoughtbot.com/geocodingonrails">https://learn.thoughtbot.com/geocodingonrails</a></p>
+<p><a href="http://geocodingonrails.com">http://geocodingonrails.com</a></p>
 </section>
 </body>
 </html>

--- a/release/geocoding-on-rails-sample.md
+++ b/release/geocoding-on-rails-sample.md
@@ -42,7 +42,7 @@ product.
 If you enjoy the sample, you can get access to the entire book and sample
 application at:
 
-<https://learn.thoughtbot.com/geocodingonrails>
+<http://geocodingonrails.com>
 
 As a purchaser of the book, you also get access to:
 
@@ -419,7 +419,7 @@ get access to the full content, the example application, ongoing updates, and
 the ability to get your questions about Ruby on Rails answered by us, you can
 pick it up on our website:
 
-<https://learn.thoughtbot.com/geocodingonrails>
+<http://geocodingonrails.com>
 
 [geocoding-on-rails-example-app-github]: https://github.com/thoughtbot/geocoding-on-rails/tree/master/example_app
 [geocoding-on-rails-example-app-readme]: https://github.com/thoughtbot/geocoding-on-rails/blob/master/example_app/README.md


### PR DESCRIPTION
I received the following via email:

> Also, I'm thinking of picking up the geocoding book,
> and in the sample:
> http://thoughtbot.com/geocoding-sample.pdf
> 
> there is a link to:
> 
> https://learn.thoughtbot.com/geocodingonrails
> 
> which 301's to a 404: (using a number as verb is weird)
> 
> https://upcase.com/geocodingonrails
